### PR TITLE
Fetcher errors handling refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 	go build -o ${EXEC} ${PKG}
 
 test:
-	go test -v ${PKG}/...
+	go test -v -timeout 2m ${PKG}/...
 
 # FIXME: we shall compile libgit2 statically with git2go to prevent libgit2
 # from being a dependency to run crawld

--- a/crawld.conf.sample
+++ b/crawld.conf.sample
@@ -18,7 +18,7 @@
     "max_fetcher_workers": 4,
     "throttler_wait_time": 900,
     "throttler_sliding_window_size": 60,
-    "throttler_max_error_rate": 1.0,
+    "throttler_leak_interval": 1000,
     "crawlers": [
         {
             "type": "github",

--- a/crawld.conf.sample
+++ b/crawld.conf.sample
@@ -16,6 +16,9 @@
     ],
     "tar_repositories": true,
     "max_fetcher_workers": 4,
+    "throttler_wait_time": 900,
+    "throttler_sliding_window_size": 60,
+    "throttler_max_error_rate": 1.0,
     "crawlers": [
         {
             "type": "github",

--- a/crawld.go
+++ b/crawld.go
@@ -283,7 +283,7 @@ func main() {
 
 	// start the repo puller worker
 	if !*disableFetcher {
-		errBag, err := errbag.New(cfg.ThrottlerWaitTime, cfg.SlidingWindowSize, cfg.MaxErrorRate)
+		errBag, err := errbag.New(cfg.ThrottlerWaitTime, cfg.SlidingWindowSize, cfg.LeakInterval)
 		if err != nil {
 			glog.Error("impossible to start the repositories fetcher")
 			return

--- a/errbag/errbag.go
+++ b/errbag/errbag.go
@@ -1,0 +1,71 @@
+// Copyright 2014-2015 The DevMine authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errbag implements an error rate based throttler. It can be used to
+// to limit function calls rate once a certain error rate threshold has been
+// reached.
+package errbag
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrBag is very effective at preventing an error rate to reach a
+// certain threshold.
+type ErrBag struct {
+	waitTime uint
+	leakRate float64
+	errChan  chan error
+}
+
+// New creates a new ErrBag, for safety purpose. waitTime corresponds to the
+// number of seconds to wait when the error rate threshold is reached.
+// slidingWindow is, in seconds, the size of the sliding window to consider
+// for throttling. leakRate corresponds to the rate at which errors are leaked
+// from the errbag in terms of errors per second. At a rate of 1, it will take
+// exactly slidingWindow seconds to empty the errbag if it is full, considering
+// no other errors are recorded during that time.
+func New(waitTime, slidingWindow uint, leakRate float64) (*ErrBag, error) {
+	if leakRate <= 0 {
+		return nil, errors.New("leakRate cannot be less than or equal to 0")
+	}
+	errChan := make(chan error, slidingWindow)
+	return &ErrBag{waitTime: waitTime, leakRate: leakRate, errChan: errChan}, nil
+}
+
+// Inflate needs to be called once to prepare the ErrBag. Once the ErrBag
+// is not needed anymore, a proper call to Deflate() shall be made.
+func (eb ErrBag) Inflate() {
+	go eb.airLeak()
+}
+
+// Deflate needs to be called when the errbag is of no use anymore.
+// Calling Record() with a deflated errbag will induce a panic.
+func (eb ErrBag) Deflate() {
+	close(eb.errChan)
+}
+
+// Record records an error if its value is non nil. It shall be called
+// by any function returning an error in order to properly rate limit the
+// errors produced. RecordError will wait for waitTime minutes if the error
+// rate is too high.
+// Note that record will panic if called after Deflate() has been called.
+func (eb ErrBag) Record(err error) {
+	if err != nil {
+		select {
+		case eb.errChan <- err:
+		default:
+			time.Sleep(time.Second * time.Duration(eb.waitTime))
+		}
+	}
+}
+
+// airLeak leaks error from the errbag at leakRate until the error channel
+// is closed.
+func (eb ErrBag) airLeak() {
+	for _, ok := <-eb.errChan; ok; _, ok = <-eb.errChan {
+		time.Sleep(time.Second * time.Duration(eb.leakRate))
+	}
+}

--- a/errbag/errbag_test.go
+++ b/errbag/errbag_test.go
@@ -1,0 +1,64 @@
+// Copyright 2014-2015 The DevMine authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package errbag
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestErrBag(t *testing.T) {
+	var waitTime, slidingWindow uint
+	var leakRate float64
+
+	waitTime, slidingWindow, leakRate = 5, 60, -1.0
+
+	if _, err := New(waitTime, slidingWindow, leakRate); err == nil {
+		t.Fatal("negative leak rate shall not be permitted")
+	}
+
+	leakRate = 1.0
+	errBag, err := New(waitTime, slidingWindow, leakRate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errBag.Inflate()
+
+	err = errors.New("foo error")
+	var i uint
+
+	// test that it does not block on less than 1 error per second
+	start := time.Now()
+	for i = 0; i < 4; i++ {
+		errBag.Record(err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > time.Second*time.Duration(waitTime) {
+		t.Fatal("throttling when error rate is low")
+	}
+
+	// now test throttling
+	start = time.Now()
+	for i = 0; i < slidingWindow+3; i++ {
+		errBag.Record(err)
+	}
+	elapsed = time.Since(start)
+	if elapsed < time.Second*time.Duration(waitTime) {
+		t.Fatal("failed to throttle")
+	}
+
+	// errBag is full of errors, deflate shall empty it
+	errBag.Deflate()
+
+	// attempting to record errors now shall panic
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("call to Record() shall panic")
+		}
+	}()
+	errBag.Record(err)
+}


### PR DESCRIPTION
This PR modifies heavily how errors are handled by the fetcher. The previous way of doing, ie relying on the type of errors produced by the functions used to fetch, revealed to be unreliable.

Hence, add a new error rate based throttler to pause the fetching task when too many errors are produced, which is likely a sign that something bad is happening to the system (network is down, storage is full, etc).

Tests were written to ensure the throttler behaves correctly but please, review with care as there is probably room for some improvements.
