### PR TITLE
Implement feature that allows the use of a temporary directory for update/clone operations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,16 @@ type Config struct {
 	// TarRepos tells whether repositories shall be stored as tar archives.
 	TarRepos bool `json:"tar_repositories"`
 
+	// TmpDir can be used to specify a temporary working directory. If
+	// left unspecified, the default system temporary directory will be used.
+	// If you have a ramdisk, you are advised to use it here.
+	TmpDir string `json:"tmp_dir"`
+
+	// TmpDirFileSizeLimit can be used to specify the maximum size in GB of an
+	// object to be temporarily placed in TmpDir for processing. Files of size
+	// larger than this value will not be processed in TmpDir.
+	TmpDirFileSizeLimit float64 `json:"tmp_dir_file_size_limit"`
+
 	// MaxFetcherWorkers defines the maximum number of workers for the
 	// repositories fetching task.
 	// It defaults to 1 but if your machine has good I/O throughput and a good
@@ -151,6 +161,10 @@ func ReadConfig(path string) (*Config, error) {
 	cfg := new(Config)
 	if err := json.Unmarshal(bs, cfg); err != nil {
 		return nil, err
+	}
+
+	if cfg.TmpDirFileSizeLimit < 0.1 {
+		cfg.TmpDirFileSizeLimit = 0.1
 	}
 
 	if cfg.MaxFetcherWorkers < 1 {

--- a/crawld.conf.sample
+++ b/crawld.conf.sample
@@ -15,6 +15,8 @@
         "ruby"
     ],
     "tar_repositories": true,
+    "tmp_dir": "/ramdisk",
+    "tmp_dir_file_size_limit": 2.0,
     "max_fetcher_workers": 4,
     "throttler_wait_time": 900,
     "throttler_sliding_window_size": 60,

--- a/repo/git.go
+++ b/repo/git.go
@@ -32,6 +32,10 @@ func (gr gitRepo) AbsPath() string {
 	return gr.absPath
 }
 
+func (gr *gitRepo) SetAbsPath(path string) {
+	gr.absPath = path
+}
+
 // URL implements the URL() method of the Repo interface.
 func (gr gitRepo) URL() string {
 	return gr.url

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -26,6 +26,9 @@ type Repo interface {
 	// AbsPath gives the absolute path to the repository on disk.
 	AbsPath() string
 
+	// SetAbsPath can be used to change AbsPath, if necessary.
+	SetAbsPath(path string)
+
 	// URL gives the clone URL of the repository.
 	URL() string
 


### PR DESCRIPTION
A temporary directory allows the user to use a ramdisk to speed up clone/update operations and spare some disk I/Os when using the tar option. Implements #13.
